### PR TITLE
Add Vulnerability Disclosure Policy link

### DIFF
--- a/_includes/components/footer.html
+++ b/_includes/components/footer.html
@@ -25,7 +25,6 @@
                 href="https://www.gsa.gov/website-information/accessibility-statement"
                 class="usa-identifier__required-link usa-link">Accessibility statement</a></li>
             <li class="usa-identifier__required-links-item"><a
-                href="<li class="usa-identifier__required-links-item"><a
                 href="https://www.gsa.gov/vulnerability-disclosure-policy"
                 class="usa-identifier__required-link usa-link">Vulnerability Disclosure Policy</a></li>
             <li class="usa-identifier__required-links-item"><a

--- a/_includes/components/footer.html
+++ b/_includes/components/footer.html
@@ -25,6 +25,10 @@
                 href="https://www.gsa.gov/website-information/accessibility-statement"
                 class="usa-identifier__required-link usa-link">Accessibility statement</a></li>
             <li class="usa-identifier__required-links-item"><a
+                href="<li class="usa-identifier__required-links-item"><a
+                href="https://www.gsa.gov/vulnerability-disclosure-policy"
+                class="usa-identifier__required-link usa-link">Vulnerability Disclosure Policy</a></li>
+            <li class="usa-identifier__required-links-item"><a
                 href="https://www.gsa.gov/reference/freedom-of-information-act-foia"
                 class="usa-identifier__required-link usa-link">FOIA requests</a></li>
             <li class="usa-identifier__required-links-item"><a

--- a/_includes/components/footer.html
+++ b/_includes/components/footer.html
@@ -22,11 +22,11 @@
             <li class="usa-identifier__required-links-item"><a href="https://www.gsa.gov/about-us"
                 class="usa-identifier__required-link usa-link">About GSA</a></li>
             <li class="usa-identifier__required-links-item"><a
+                href="https://www.gsa.gov/vulnerability-disclosure-policy"
+                class="usa-identifier__required-link usa-link">Vulnerability Disclosure Policy</a></li>                
+            <li class="usa-identifier__required-links-item"><a
                 href="https://www.gsa.gov/website-information/accessibility-statement"
                 class="usa-identifier__required-link usa-link">Accessibility statement</a></li>
-            <li class="usa-identifier__required-links-item"><a
-                href="https://www.gsa.gov/vulnerability-disclosure-policy"
-                class="usa-identifier__required-link usa-link">Vulnerability Disclosure Policy</a></li>
             <li class="usa-identifier__required-links-item"><a
                 href="https://www.gsa.gov/reference/freedom-of-information-act-foia"
                 class="usa-identifier__required-link usa-link">FOIA requests</a></li>


### PR DESCRIPTION
Added GSA's Vulnerability Disclosure Police link to site footer per M-23-22:

[Preview](https://federalist-37831b52-7633-429a-9a79-14298034dd54.sites.pages.cloud.gov/preview/gsa-tts/10x-website/jd-add-new-required-links/)